### PR TITLE
Handle edge-to-edge insets to prevent status bar overlap

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,9 +40,9 @@ java {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.13.1'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "androidx.camera:camera-core:1.4.1"
     implementation "androidx.camera:camera-camera2:1.4.1"
     implementation "androidx.camera:camera-lifecycle:1.4.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ java {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/app/src/main/java/jp/axinc/ailia_kotlin/MainActivity.kt
+++ b/app/src/main/java/jp/axinc/ailia_kotlin/MainActivity.kt
@@ -129,9 +129,11 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         // Android 15 (targetSdk 35) 以降はエッジツーエッジが強制されるため、
-        // システムバー/ディスプレイカットアウトのインセットを上下左右のpaddingとして適用する
-        val rootView = findViewById<View>(android.R.id.content)
-        ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
+        // システムバー/ディスプレイカットアウトのインセットを上下左右のpaddingとして適用する。
+        // ActionBar が消費した後の残りのインセット(ステータスバー分は消費済み)を
+        // コンテンツのルートに反映することで、ナビゲーションバー/ノッチとの被りを防ぐ。
+        val rootLayout = findViewById<View>(R.id.rootLayout)
+        ViewCompat.setOnApplyWindowInsetsListener(rootLayout) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
             )

--- a/app/src/main/java/jp/axinc/ailia_kotlin/MainActivity.kt
+++ b/app/src/main/java/jp/axinc/ailia_kotlin/MainActivity.kt
@@ -21,6 +21,8 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import axip.ailia.*
 import axip.ailia_tflite.*
 import axip.ailia_llm.AiliaLLM
@@ -125,6 +127,17 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // Android 15 (targetSdk 35) 以降はエッジツーエッジが強制されるため、
+        // システムバー/ディスプレイカットアウトのインセットを上下左右のpaddingとして適用する
+        val rootView = findViewById<View>(android.R.id.content)
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            v.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+            insets
+        }
 
         // cameraExecutorはsetupModeSelection()より先に初期化する必要がある
         // (SpinnerのonItemSelectedでinitializeAilia()が呼ばれるため)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">


### PR DESCRIPTION
Android 15+ (targetSdk 35) enforces edge-to-edge, causing the status bar to overlap the top UI on Android 16. Apply system bar and display cutout insets as padding on all sides of the root view.

Bump androidx.core:core-ktx to 1.13.1 for the WindowInsetsCompat.Type API.